### PR TITLE
Omero build improvements

### DIFF
--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -27,6 +27,7 @@
       <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
         <relativeTargetDir>src</relativeTargetDir>
       </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
     </extensions>
   </scm>
   <canRoam>true</canRoam>

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -37,12 +37,6 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command># from https://github.com/openmicroscopy/openmicroscopy/pull/3944
-echo ome.resolver=ome-simple-artifactory &gt; src/etc/local.properties
-echo simple.repository=ome.SPACENAME &gt;&gt; src/etc/local.properties
-echo versions.bioformats=5.1.3-SNAPSHOT &gt;&gt; src/etc/local.properties</command>
-    </hudson.tasks.Shell>
-    <hudson.tasks.Shell>
       <command>eval $(bash /opt/multi-config.sh ice3.5)
 
 export PATH=/opt/texlive/bin/x86_64-linux:$PATH # for dockerfile


### PR DESCRIPTION
Following modifications brought to the OMERO-build while working on the regions space, this PR:

- drops the hardcoded SNAPSHOT bump (in favor of a PR against the branch)
- cleans the Git source code directory after checkout to remove untracked files