### PR TITLE
Fix OMERO-start

### DIFF
--- a/home/jobs/OMERO-start/config.xml
+++ b/home/jobs/OMERO-start/config.xml
@@ -74,7 +74,7 @@ psql -h pg -U postgres -d $OMERO_DB_NAME -f dbsetup.sql
 rm dbsetup.sql
 
 BUILD_ID=DONT_KILL_ME bin/omero admin start
-BUILD_ID=DONT_KILL_ME bin/omero web start
+# BUILD_ID=DONT_KILL_ME bin/omero web start
 
 bin/omero admin waitup
 

--- a/home/jobs/OMERO-start/config.xml
+++ b/home/jobs/OMERO-start/config.xml
@@ -46,7 +46,7 @@ source docs/hudson/functions.sh
 
 
 # PURGE
-dist/bin/omero admin stop || echo First build
+dist/bin/omero admin stop --force-rewrite || echo First build
 sleep 5
 
 mkdir -p $OMERO_DATA_DIR

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -3,6 +3,7 @@ FROM openmicroscopy/omero-build-c6-multienv
 MAINTAINER OME
 
 ENV JENKINS_SWARM_VERSION 1.24
+ENV LANG en_US.UTF-8
 
 RUN adduser -u 1000 slave
 USER slave


### PR DESCRIPTION
See https://trello.com/c/wDtIyhJ7/133-fix-omero-start-in-ci. Using the vanilla devspace, some server integration tests currently fail due to a missing locale. The current workaround is to prepend shell blocks with `export PATH=...`.

This PR:
- modified the slave Dockerfile to add `ENV LANG`
- adds `--force-rewrite to the initial server stop command
- temporarily disables the Web deployment. Minimally `pip -r install share/web/...` needs to be preprended to the call but then `bin/omero web start` fails with 

  ```
Clearing expired sessions. This may take some time... [OK]
Starting OMERO.web... Traceback (most recent call last):
  File "bin/omero", line 125, in <module>
    rv = omero.cli.argv()
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/cli.py", line 1432, in argv
    cli.invoke(args[1:])
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/cli.py", line 946, in invoke
    stop = self.onecmd(line, previous_args)
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/cli.py", line 1023, in onecmd
    self.execute(line, previous_args)
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/cli.py", line 1105, in execute
    args.func(args)
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/plugins/web.py", line 74, in wrapper
    return func(self, *args, **kwargs)
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/plugins/web.py", line 507, in start
    rv = self.ctx.popen(args=runserver, cwd=location)  # popen
  File "/home/slave/workspace/OMERO-start/openmicroscopy-5.2.1-77-68ff9aa/dist/lib/python/omero/cli.py", line 1196, in popen
    stdout=stdout, stderr=stderr)
  File "/usr/lib64/python2.6/subprocess.py", line 642, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.6/subprocess.py", line 1234, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
Build step 'Execute shell' marked build as failure
```

I suggest we revisit the latter when activating the Robot tests against Web.

Tested via http://develop-ci.docker.openmicroscopy.org:8080/job/OMERO-start/3/consoleFull