### PR TITLE
Jenkins slave SERVICE_NAME

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ slave:
         - git
     environment:
         - JAVA_HOME=/etc/alternatives/java_sdk
-        - SERVICE_NAME=regions-omero
+        - SERVICE_NAME=SPACENAME-omero
     ports:
         - "4064:4064"
         - "4063:4063"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ slave:
         - git
     environment:
         - JAVA_HOME=/etc/alternatives/java_sdk
+        - SERVICE_NAME=regions-omero
+    ports:
+        - "4064:4064"
+        - "4063:4063"
 
 nginx:
     image: nginx

--- a/rename.py
+++ b/rename.py
@@ -33,5 +33,5 @@ if __name__ == "__main__":
     branch = name
 
   # This number will need to be updated when new changes are commited.
-  assert 15 == replace(name, branch, ns.uid)
+  assert 16 == replace(name, branch, ns.uid)
   print "Done. You may want to review and commit your changes now"


### PR DESCRIPTION
This PR defines a `SERVICE_NAME` in the Jenkins Docker slave allowing Java clients to connect to the integration server spin up by OMERO-start.

This change should have been applied to and tested by the `regions-ci` devspace /cc @mtbc @dominikl 