### PR TITLE
Add JDK8 to the Jenkins configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,13 @@ slave/omero
 slave/tools
 slave/workspace
 slave/*.jar
-slave/.install4j
+slave/.bash_history
 slave/.exe4j4
-slave/.ssh
+slave/.install4j
 slave/.gitconfig
 slave/.java
 slave/.jenkins
 slave/.matplotlib
+slave/.oracle_jre_usage
 slave/.local
+slave/.ssh

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ slave/workspace
 slave/*.jar
 slave/.ssh
 slave/.gitconfig
+slave/.java
 slave/.jenkins
 slave/.matplotlib
 slave/.local

--- a/home/config.xml
+++ b/home/config.xml
@@ -11,7 +11,22 @@
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
   <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
   <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
-  <jdks/>
+  <jdks>
+    <jdk>
+      <name>JDK8</name>
+      <home></home>
+      <properties>
+        <hudson.tools.InstallSourceProperty>
+          <installers>
+            <hudson.tools.JDKInstaller>
+              <id>jdk-8u72-oth-JPR</id>
+              <acceptLicense>true</acceptLicense>
+            </hudson.tools.JDKInstaller>
+          </installers>
+        </hudson.tools.InstallSourceProperty>
+      </properties>
+    </jdk>
+  </jdks>
   <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
   <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
   <clouds/>

--- a/home/config.xml
+++ b/home/config.xml
@@ -19,7 +19,7 @@
         <hudson.tools.InstallSourceProperty>
           <installers>
             <hudson.tools.JDKInstaller>
-              <id>jdk-8u72-oth-JPR</id>
+              <id>jdk-8u74-oth-JPR</id>
               <acceptLicense>true</acceptLicense>
             </hudson.tools.JDKInstaller>
           </installers>


### PR DESCRIPTION
This PR defines a Jenkins JDK to be used by jobs. Longer term, we might to make this more configurable to allow different devspaces to be started for each JDK. 
This change should be deployed and tested on `develop-ci` and should remove all Javadoc warnings in OMERO-build.