### PR TITLE
Do not forward 4063/4064 ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,6 @@ slave:
     environment:
         - JAVA_HOME=/etc/alternatives/java_sdk
         - SERVICE_NAME=SPACENAME-omero
-    ports:
-        - "4064:4064"
-        - "4063:4063"
 
 nginx:
     image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ slave:
     environment:
         - JAVA_HOME=/etc/alternatives/java_sdk
         - SERVICE_NAME=SPACENAME-omero
+        - DOCKER_FIX='   '
 
 nginx:
     image: nginx


### PR DESCRIPTION
Tested on `regions-ci`, this should stop the port forwarding and prevent conflicts between devspaces on the same host. This should not prevent Insight from connecting to the `SERVICE-omero` integration server on port 4064 /cc @jburel 