### PR TITLE
Cap the number of OMERO-build artifacts to keep to 5

### DIFF
--- a/home/jobs/BIOFORMATS-maven/config.xml
+++ b/home/jobs/BIOFORMATS-maven/config.xml
@@ -3,7 +3,16 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties/>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>5</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+  </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -3,7 +3,16 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties/>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>5</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+  </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.0">
     <configVersion>2</configVersion>
     <userRemoteConfigs>


### PR DESCRIPTION
As we introduced previously in the mainline CI, this should prevent devspaces from growing exponentially as they retain the build artifacts.

NOte this has been applied to the regions-ci and reduced the size from 95G to 25G. /cc @manics @aleksandra-tarkowska  @kennethgillen 