### PR TITLE
Add Script Security Plugin 1.18.1 to the list of plugins

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -10,6 +10,7 @@ credentials:1.22
 rundeck:3.5.1
 junit:1.9
 javadoc:1.3
+script-security:1.18.1
 
 artifactory:2.4.4
 copyartifact:1.37


### PR DESCRIPTION
Following https://wiki.jenkins-ci.org/display/SECURITY/Jenkins+Security+Advisory+2016-04-11 this should allow to deploy the latest version of the script security plugins on devspaces. /cc @kennethgillen @aleksandra-tarkowska 