### PR TITLE
Add description linking to the source code repository

### DIFF
--- a/home/config.xml
+++ b/home/config.xml
@@ -11,6 +11,9 @@
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
   <workspaceDir>${ITEM_ROOTDIR}/workspace</workspaceDir>
   <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter" plugin="antisamy-markup-formatter@1.1">
+    <disableSyntaxHighlighting>false</disableSyntaxHighlighting>
+  </markupFormatter>
   <jdks>
     <jdk>
       <name>JDK8</name>
@@ -36,6 +39,7 @@
     <hudson.model.AllView>
       <owner class="hudson" reference="../../.."/>
       <name>All</name>
+      <description>See &lt;a href=&quot;https://github.com/openmicroscopy/devspace#job-workflow&quot;&gt;Job workflow&lt;/a&gt; for more information</description>
       <filterExecutors>false</filterExecutors>
       <filterQueue>false</filterQueue>
       <properties class="hudson.model.View$PropertyList"/>

--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description></description>
+  <description>For more info, see the &lt;a href=&quot;https://github.com/openmicroscopy/devspace#job-workflow&quot;/&gt;Job workflow&lt;/a&gt;.</description>
   <keepDependencies>false</keepDependencies>
   <properties/>
   <scm class="hudson.scm.NullSCM"/>


### PR DESCRIPTION
Last backport from the to-be-decommissioned `regions-ci` devspace, this commit adds a description at the top of the devspace linking to the README.md for minimal documentation of the workflow. /cc @pwalczysko 