### PR TITLE
Bugfix: mount nginx as /home/omero

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ nginx:
         - jenkins
         - web
     volumes:
+        - ./nginx:/home/omero
         - ./nginx/conf.d:/etc/nginx/conf.d
         - ./web/static:/home/omero/static
     environment:


### PR DESCRIPTION
0.2.0 (#31) works fine for user 1000 on openstack or docker-machine, but for higher users, the nginx job fails. This change corrects that.