### PR TITLE
Bio-Formats Ant build job

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ they are associated with and a short description of the job:
 | -----------------------|-----------------| ------------------------------------------|
 | Trigger                |                 | Runs all the following jobs in order      |
 | BIOFORMATS-push        | testintegration | Merges all Bio-Formats PRs                |
+| BIOFORMATS-ant         | bf              | Builds Bio-Formats and runs unit tests    |
 | BIOFORMATS-maven       | testintegration | Builds Bio-Formats and runs unit tests    |
 | OMERO-push             | testintegration | Merges all OMERO PRs                      |
 | OMERO-build            | testintegration | Builds OMERO artifacts (server, clients)  |

--- a/bf/Dockerfile
+++ b/bf/Dockerfile
@@ -9,6 +9,9 @@ RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDB
     tar xzf findbugs-$FINDBUGS_VERSION.tar.gz --strip-components 1 -C $FINDBUGS_HOME && \
     rm findbugs-$FINDBUGS_VERSION.tar.gz
 
+# Install Sphinx
+RUN pip install Sphinx
+
 # Change user id to fix permissions issues
 ARG USER_ID=1000
 RUN usermod -u $USER_ID omero

--- a/bf/Dockerfile
+++ b/bf/Dockerfile
@@ -10,6 +10,7 @@ RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDB
     rm findbugs-$FINDBUGS_VERSION.tar.gz
 
 # Install Sphinx
+RUN yum -y install python-pip
 RUN pip install Sphinx
 
 # Change user id to fix permissions issues

--- a/bf/Dockerfile
+++ b/bf/Dockerfile
@@ -6,7 +6,7 @@ ENV FINDBUGS_VERSION 3.0.0
 ENV FINDBUGS_HOME /opt/findbugs
 RUN mkdir -p $FINDBUGS_HOME
 RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDBUGS_VERSION/findbugs-$FINDBUGS_VERSION.tar.gz && \
-    tar xzf findbugs-$FINDBUGS_VERSION.tar.gz -C $FINDBUGS_HOME && \
+    tar xzf findbugs-$FINDBUGS_VERSION.tar.gz --strip-components 1 -C $FINDBUGS_HOME && \
     rm findbugs-$FINDBUGS_VERSION.tar.gz
 
 # Change user id to fix permissions issues

--- a/bf/Dockerfile
+++ b/bf/Dockerfile
@@ -12,3 +12,5 @@ RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDB
 # Change user id to fix permissions issues
 ARG USER_ID=1000
 RUN usermod -u $USER_ID omero
+
+USER omero

--- a/bf/Dockerfile
+++ b/bf/Dockerfile
@@ -1,0 +1,6 @@
+FROM openmicroscopy/devslave-c7:0.2.1
+MAINTAINER OME
+
+# Change user id to fix permissions issues
+ARG USER_ID=1000
+RUN usermod -u $USER_ID omero

--- a/bf/Dockerfile
+++ b/bf/Dockerfile
@@ -1,6 +1,14 @@
 FROM openmicroscopy/devslave-c7:0.2.1
 MAINTAINER OME
 
+# Install FindBugs
+ENV FINDBUGS_VERSION 3.0.0
+ENV FINDBUGS_HOME /opt/findbugs
+RUN mkdir -p $FINDBUGS_HOME
+RUN curl -fSLO http://downloads.sourceforge.net/project/findbugs/findbugs/$FINDBUGS_VERSION/findbugs-$FINDBUGS_VERSION.tar.gz && \
+    tar xzf findbugs-$FINDBUGS_VERSION.tar.gz -C $FINDBUGS_HOME && \
+    rm findbugs-$FINDBUGS_VERSION.tar.gz
+
 # Change user id to fix permissions issues
 ARG USER_ID=1000
 RUN usermod -u $USER_ID omero

--- a/common-services-v1.yml
+++ b/common-services-v1.yml
@@ -8,6 +8,7 @@ baseslave:
     build: ./slave
     volumes:
         - ./slave:/home/omero
+        - /ome:/ome
     environment:
         - SLAVE_NAME=baseslave
         - SLAVE_EXECUTORS=2

--- a/common-services-v1.yml
+++ b/common-services-v1.yml
@@ -4,11 +4,19 @@
 # web is a container with basic omero web dependances
 # nginx is a nginx container for omero web
 
+basebf:
+    build: ./bf
+    volumes:
+        - ./bf:/home/omero
+    environment:
+        - SLAVE_NAME=basebf
+        - SLAVE_EXECUTORS=2
+        - SLAVE_PARAMS=-labels centos7 -labels java -disableClientsUniqueId
+
 baseslave:
     build: ./slave
     volumes:
         - ./slave:/home/omero
-        - /ome:/ome
     environment:
         - SLAVE_NAME=baseslave
         - SLAVE_EXECUTORS=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ bf:
         - jenkins
     volumes:
         - ./bf:/home/omero
-        - /ome:/ome
     environment:
         - SLAVE_NAME=bf
         - SLAVE_PARAMS=-labels centos7 -labels java18 -disableClientsUniqueId

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,19 @@ pg:
     volumes:
         - ./pgdata:/var/lib/postgresql/data
 
+bf:
+    extends:
+        file: common-services-v1.yml
+        service: basebf
+    links:
+        - jenkins
+    volumes:
+        - ./bf:/home/omero
+        - /ome:/ome
+    environment:
+        - SLAVE_NAME=bf
+        - SLAVE_PARAMS=-labels centos7 -labels java18 -disableClientsUniqueId
+        
 testintegration:
     extends:
         file: common-services-v1.yml

--- a/home/hudson.tasks.Ant.xml
+++ b/home/hudson.tasks.Ant.xml
@@ -1,4 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson.tasks.Ant_-DescriptorImpl plugin="ant@1.2">
-  <installations/>
+  <installations>
+    <hudson.tasks.Ant_-AntInstallation>
+      <name>Ant 1.9</name>
+      <home></home>
+      <properties>
+        <hudson.tools.InstallSourceProperty>
+          <installers>
+            <hudson.tasks.Ant_-AntInstaller>
+              <id>1.9.7</id>
+            </hudson.tasks.Ant_-AntInstaller>
+          </installers>
+        </hudson.tools.InstallSourceProperty>
+      </properties>
+    </hudson.tasks.Ant_-AntInstallation>
+  </installations>
 </hudson.tasks.Ant_-DescriptorImpl>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -49,7 +49,6 @@
       <antName>(Default)</antName>
       <buildFile>components/test-suite/build.xml</buildFile>
     </hudson.tasks.Ant>
-    </hudson.tasks.Ant>
   </builders>
   <publishers/>
   <buildWrappers/>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -12,6 +12,15 @@
         <artifactNumToKeep>5</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>findbugs.home</name>
+          <description></description>
+          <defaultValue>/opt/findbugs</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
   </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.0">
     <configVersion>2</configVersion>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -52,11 +52,6 @@
       <targets>clean release jars tools utils dist-bftools docs test findbugs dist-matlab</targets>
       <antName>Ant 1.9</antName>
     </hudson.tasks.Ant>
-    <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>test-tiff-compress</targets>
-      <antName>Ant 1.9</antName>
-      <buildFile>components/test-suite/build.xml</buildFile>
-    </hudson.tasks.Ant>
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>5</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://github.com/openmicroscopy/bioformats</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>*/develop</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <assignedNode>bf</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Ant plugin="ant@1.2">
+      <targets>jars</targets>
+      <antName>Ant 1.9</antName>
+    </hudson.tasks.Ant>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -36,7 +36,6 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <jdk>JDK8</jdk>
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -22,7 +22,7 @@
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/develop</name>
+        <name>SPACEBRANCH/merge/trigger</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -53,7 +53,7 @@
       <antName>Ant 1.9</antName>
     </hudson.tasks.Ant>
     <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>test-tiff-compress test-minimal-convert</targets>
+      <targets>test-tiff-compress</targets>
       <antName>Ant 1.9</antName>
       <buildFile>components/test-suite/build.xml</buildFile>
     </hudson.tasks.Ant>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -54,10 +54,23 @@
     </hudson.tasks.Ant>
     <hudson.tasks.Ant plugin="ant@1.2">
       <targets>test-tiff-compress test-minimal-convert</targets>
-      <antName>(Default)</antName>
+      <antName>Ant 1.9</antName>
       <buildFile>components/test-suite/build.xml</buildFile>
     </hudson.tasks.Ant>
   </builders>
-  <publishers/>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>artifacts/*.jar, artifacts/*.zip</artifacts>
+      <allowEmptyArchive>false</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
+    <hudson.tasks.JavadocArchiver plugin="javadoc@1.3">
+      <javadocDir>build/docs/api</javadocDir>
+      <keepAll>false</keepAll>
+    </hudson.tasks.JavadocArchiver>
+  </publishers>
   <buildWrappers/>
 </project>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -17,7 +17,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>https://github.com/openmicroscopy/bioformats</url>
+        <url>https://github.com/snoopycrimecop/bioformats</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
@@ -27,19 +27,28 @@
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
     <submoduleCfg class="list"/>
-    <extensions/>
+    <extensions>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
+    </extensions>
   </scm>
   <assignedNode>bf</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <jdk>JDK8</jdk>
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>jars</targets>
+      <targets>clean release jars tools tools-ome utils dist-bftools docs test findbugs dist-matlab</targets>
       <antName>Ant 1.9</antName>
+    </hudson.tasks.Ant>
+    <hudson.tasks.Ant plugin="ant@1.2">
+      <targets>test-tiff-compress test-minimal-convert</targets>
+      <antName>(Default)</antName>
+      <buildFile>components/test-suite/build.xml</buildFile>
+    </hudson.tasks.Ant>
     </hudson.tasks.Ant>
   </builders>
   <publishers/>

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -49,7 +49,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>clean release jars tools tools-ome utils dist-bftools docs test findbugs dist-matlab</targets>
+      <targets>clean release jars tools utils dist-bftools docs test findbugs dist-matlab</targets>
       <antName>Ant 1.9</antName>
     </hudson.tasks.Ant>
     <hudson.tasks.Ant plugin="ant@1.2">

--- a/home/jobs/BIOFORMATS-ant/config.xml
+++ b/home/jobs/BIOFORMATS-ant/config.xml
@@ -49,7 +49,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Ant plugin="ant@1.2">
-      <targets>clean release jars tools utils dist-bftools docs test findbugs dist-matlab</targets>
+      <targets>clean release jars tools utils dist-bftools dist-matlab docs docs-sphinx test findbugs</targets>
       <antName>Ant 1.9</antName>
     </hudson.tasks.Ant>
   </builders>

--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -7,7 +7,9 @@
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@1.11">
     <script>build job: &apos;BIOFORMATS-push&apos;
 
-build &apos;BIOFORMATS-maven&apos;
+build job: &apos;BIOFORMATS-maven&apos;
+
+build job: &apos;BIOFORMATS-ant&apos;
 
 build job: &apos;OMERO-push&apos;
 


### PR DESCRIPTION
See https://trello.com/c/aoMEGJ9E/10-ci-ant-jobs

While working on upstream changes, this PR ports the Continuous Integration job building Bio-Formats using Ant into devspace.

The following changes are included:
- defines a new base image is created for the Bio-Formats builds (based on plain `devspace_c7`)
- dependencies are added for `findbugs` and the `Sphinx` documentation build
- a new template `BIOFORMATS-ant` job is added to the list/trigger job

The companion infrastructure PR used to deploy the HEAD of this branch is https://github.com/openmicroscopy/infrastructure/pull/141