### PR TITLE
don't run new BF-ant job as develop branch is not ready

### DIFF
--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -9,7 +9,7 @@
 
 build job: &apos;BIOFORMATS-maven&apos;
 
-build job: &apos;BIOFORMATS-ant&apos;
+//build job: &apos;BIOFORMATS-ant&apos;
 
 build job: &apos;OMERO-push&apos;
 


### PR DESCRIPTION
This PR is a minor fix for 

```
BUILD FAILED
/home/omero/workspace/BIOFORMATS-ant/ant/toplevel.xml:193: The following error occurred while executing this line:
/home/omero/workspace/BIOFORMATS-ant/docs/sphinx/build.xml:131: The following error occurred while executing this line:
/home/omero/workspace/BIOFORMATS-ant/docs/sphinx/build.xml:136: The following error occurred while executing this line:
/home/omero/workspace/BIOFORMATS-ant/docs/sphinx/build.xml:114: The following error occurred while executing this line:
/home/omero/workspace/BIOFORMATS-ant/docs/sphinx/build.xml:89: Execute failed: java.io.IOException: Cannot run program "xelatex" (in directory "/home/omero/workspace/BIOFORMATS-ant/docs/sphinx/_build/latex"): error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at java.lang.Runtime.exec(Runtime.java:620)

```

see https://10.0.51.106:8443/job/BIOFORMATS-ant/1/console

**Please get that in asap and tag 0.3.2, then we need to bump the version like in https://github.com/openmicroscopy/infrastructure/pull/144.**

**This should be reverted once develop is ready to use the new ANT job**

cc @joshmoore @sbesson 