### PR TITLE
Revert "don;t run new BF-ant job as develop branch is not ready"

### DIFF
--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -9,7 +9,7 @@
 
 build job: &apos;BIOFORMATS-maven&apos;
 
-//build job: &apos;BIOFORMATS-ant&apos;
+build job: &apos;BIOFORMATS-ant&apos;
 
 build job: &apos;OMERO-push&apos;
 


### PR DESCRIPTION
This reverts commit 5bec7e2f787ed3c3f97f4b09d5a91c2bb550af03 following the integration of the rearchitecture work into develop as part of  https://github.com/openmicroscopy/bioformats/pull/2622