### PR TITLE
OMERO-push: SCM configuration improvements

### DIFF
--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -48,9 +48,15 @@
     </browser>
     <submoduleCfg class="list"/>
     <extensions>
+      <hudson.plugins.git.extensions.impl.SubmoduleOption>
+        <disableSubmodules>false</disableSubmodules>
+        <recursiveSubmodules>true</recursiveSubmodules>
+        <trackingSubmodules>false</trackingSubmodules>
+      </hudson.plugins.git.extensions.impl.SubmoduleOption>
       <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
         <relativeTargetDir>src</relativeTargetDir>
       </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
     </extensions>
   </scm>
   <assignedNode>testintegration</assignedNode>

--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -9,7 +9,7 @@
         <hudson.model.StringParameterDefinition>
           <name>MERGE_COMMAND</name>
           <description></description>
-          <defaultValue>merge SPACENAME --no-ask --reset</defaultValue>
+          <defaultValue>merge SPACENAME --no-ask --reset --update-gitmodules</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>STATUS</name>


### PR DESCRIPTION
- Add recursive submodule processing to allow script PRs to be merged
- Update the OMERO merge command to update the `.gitmodules`
- Add clean checkout option

Noticed while testing Pillow changes /cc @aleksandra-tarkowska @jburel 