### PR TITLE
let job progress even tests are not stable

### DIFF
--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -21,7 +21,7 @@ build job: &apos;OMERO-web&apos;
 
 build job: &apos;nginx&apos;
 
-build job: &apos;OMERO-test-integration&apos;
+build job: &apos;OMERO-test-integration&apos;, propagate: false
 
 build job: &apos;OMERO-robot&apos;, wait: false
 


### PR DESCRIPTION
Tell Trigger job that should continue when testintegration job is yellow

 ```
Scheduling project: OMERO-test-integration
Starting building project: OMERO-test-integration #66
[Workflow] End of Workflow
java.lang.Exception: UNSTABLE
    at org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerListener.onCompleted(BuildTriggerListener.java:43)
    at hudson.model.listeners.RunListener.fireCompleted(RunListener.java:201)
    at hudson.model.Run.execute(Run.java:1783)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
Finished: FAILURE
```

https://trello.com/c/by4vSu3y/75-idr-ci-trigger-should-tolerate-unstable-jobs