### PR TITLE
Update Jenkins to latest LTS (2.46.2)

### DIFF
--- a/home/config.xml
+++ b/home/config.xml
@@ -29,7 +29,7 @@
         <hudson.tools.InstallSourceProperty>
           <installers>
             <hudson.tools.JDKInstaller>
-              <id>jdk-8u121-oth-JPR</id>
+              <id>jdk-8u131-oth-JPR</id>
               <acceptLicense>true</acceptLicense>
             </hudson.tools.JDKInstaller>
           </installers>

--- a/home/config.xml
+++ b/home/config.xml
@@ -3,7 +3,7 @@
   <disabledAdministrativeMonitors>
     <string>jenkins.security.s2m.MasterKillSwitchWarning</string>
   </disabledAdministrativeMonitors>
-  <version>2.46.1</version>
+  <version>2.46.2</version>
   <numExecutors>0</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:2.46.1
+FROM jenkins:2.46.2
 MAINTAINER OME
 
 # Temp fix robot test results


### PR DESCRIPTION
Also bumps the Oracle JDK to use the latest version (publicly accessible without account)

## Testing

This branch has been deployed on https://10.0.51.140:8443/. All jobs and tests should be passing with the same caveats as the ones that apply to the current `develop` line.