### PR TITLE
Bump devslave-c7 Docker image version to 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+group: deprecated-2017Q2
 
 language: python
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.0
+FROM openmicroscopy/devslave-c7:0.3.1
 
 MAINTAINER OME
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.0
+FROM openmicroscopy/devslave-c7:0.3.1
 
 MAINTAINER OME
 

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.0
+FROM openmicroscopy/devslave-c7:0.3.1
 
 MAINTAINER OME
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.0
+FROM openmicroscopy/devslave-c7:0.3.1
 
 MAINTAINER OME
 


### PR DESCRIPTION
This should allow to consume omero-install 5.3.3 and fix the encoding issues affecting the integration tests

/cc @jburel 

Proposed tag: `0.5.2`