### PR TITLE
OMERO documentation job

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ they are associated with and a short description of the job:
 | OMERO-test-integration | testintegration | Runs the OMERO integration tests          |
 | OMERO-robot            | testintegration | Runs the Robot tests                      |
 | nginx                  | nginx           | Reloads the nginx server                  |
+| OMERO-docs             | testintegration | Builds the OMERO documentation            |
 
 
 Default packages:

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>2</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>MERGE_COMMAND</name>
+          <description></description>
+          <defaultValue>merge SPACENAME --no-ask --reset</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.2.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://github.com/openmicroscopy/ome-documentation</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>SPACEBRANCH</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+     <submoduleCfg class="list"/>
+     <extensions>
+      </hudson.plugins.git.extensions.impl.SubmoduleOption>
+      <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+        <relativeTargetDir>src</relativeTargetDir>
+      </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
+    </extensions>
+  </scm>
+  <assignedNode>testintegration</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>pip install --user scc
+test -e src &amp;&amp; cd src
+$HOME/.local/bin/scc $MERGE_COMMAND
+
+pip install --user docutils==0.12</command>
+    </hudson.tasks.Shell>
+    <hudson.tasks.Ant plugin="ant@1.4">
+      <targets>clean html</targets>
+      <antName>Ant 1.9</antName>
+      <buildFile>src/omero/build.xml</buildFile>
+    </hudson.tasks.Ant>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>src/omero/_build/html/**</artifacts>
+      <allowEmptyArchive>false</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+  </buildWrappers>
+</project>

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -55,9 +55,7 @@
     <hudson.tasks.Shell>
       <command>pip install --user scc
 test -e src &amp;&amp; cd src
-$HOME/.local/bin/scc $MERGE_COMMAND
-
-pip install --user docutils==0.12</command>
+$HOME/.local/bin/scc $MERGE_COMMAND</command>
     </hudson.tasks.Shell>
     <hudson.tasks.Ant plugin="ant@1.4">
       <targets>clean html</targets>

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -34,13 +34,9 @@
         <name>SPACEBRANCH</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
-        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
-     <submoduleCfg class="list"/>
-     <extensions>
-      </hudson.plugins.git.extensions.impl.SubmoduleOption>
-      <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-        <relativeTargetDir>src</relativeTargetDir>
-      </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions>
       <hudson.plugins.git.extensions.impl.CleanCheckout/>
     </extensions>
   </scm>
@@ -60,12 +56,12 @@ $HOME/.local/bin/scc $MERGE_COMMAND</command>
     <hudson.tasks.Ant plugin="ant@1.4">
       <targets>clean html</targets>
       <antName>Ant 1.9</antName>
-      <buildFile>src/omero/build.xml</buildFile>
+      <buildFile>omero/build.xml</buildFile>
     </hudson.tasks.Ant>
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>src/omero/_build/html/**</artifacts>
+      <artifacts>omero/_build/html/**</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>false</fingerprint>

--- a/home/jobs/Trigger/config.xml
+++ b/home/jobs/Trigger/config.xml
@@ -33,6 +33,8 @@ build job: &apos;OMERO-test-integration&apos;, propagate: false
 
 build job: &apos;OMERO-robot&apos;, wait: false
 
+build job: &apos;OMERO-docs&apos;, wait: false
+
 </script>
     <sandbox>false</sandbox>
   </definition>

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -45,8 +45,7 @@ WORKDIR /tmp/omero-install/linux
 
 RUN JAVAVER=$JAVAVER ICEVER=$ICEVER PGVER=nopg bash install_centos7_nginx.sh
 
-# install sphinx - minimum required
-RUN pip install sphinx==1.2.3
+RUN pip install Sphinx
 
 # Install FindBugs
 ENV FINDBUGS_VERSION 3.0.0


### PR DESCRIPTION
See https://trello.com/c/ccx2knE7/141-check-whether-sphinx-can-be-upgraded-for-all-docs-jobs

Prior to upgrading the Sphinx dependency on our production CI, this PR ports recent additions allowing to:

- build the OMERO documentation in a CI devspace allowing to develop and review the documentation in sync with the code
- uncap the Sphinx dependency currently set to 1.2.3 matching the upstream improvement changes (https://github.com/openmicroscopy/bioformats/pull/2862, https://github.com/openmicroscopy/ome-documentation/pull/1743 and https://github.com/openmicroscopy/ome-documentation)/pull/1745

To test this PR, review https://minke.openmicroscopy.org:32833/job/OMERO-docs/