### PR TITLE
Don't hard-code ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ testintegration:
     extra_hosts:
         - "testintegration:127.0.0.1"
     ports:
-        - "14064:14064"
-        - "14063:14063"
+        - "14064"
+        - "14063"
 
 omero:
     extends:
@@ -55,8 +55,8 @@ omero:
         # - JENKINS_USERNAME=${JENKINS_USERNAME}
         # - JENKINS_PASSWORD=${JENKINS_PASSWORD}
     ports:
-        - "4064:4064"
-        - "4063:4063"
+        - "4064"
+        - "4063"
 
 web:
     extends:
@@ -96,8 +96,8 @@ nginx:
         # - JENKINS_USERNAME=${JENKINS_USERNAME}
         # - JENKINS_PASSWORD=${JENKINS_PASSWORD}
     ports:
-        - "80:80"
-        - "443:443"
+        - "80"
+        - "443"
 
 nginxjenkins:
     image: nginx:1.10
@@ -107,7 +107,7 @@ nginxjenkins:
         - ./jenkins/conf.d:/etc/nginx/conf.d
         - ./jenkins/sslcert:/etc/nginx/ssl
     ports:
-        - "8443:443"
+        - "443"
 redis:
     image: redis
 
@@ -121,7 +121,7 @@ seleniumhub:
 #    volumes:
 #        - /dev/urandom:/dev/random
     ports:
-        - "4444:4444"
+        - "4444"
 seleniumfirefox:
     image: selenium/node-firefox:3.0.0-dubnium
     links:

--- a/runtest.sh
+++ b/runtest.sh
@@ -53,9 +53,10 @@ do
 done
 
 
-curl -k -I https://localhost:8443
+JENKINS_PORT=$(docker-compose port nginxjenkins 443 | cut -d: -f2)
+curl -k -I https://localhost:$JENKINS_PORT
 
-STATUS=`curl -k --write-out %{http_code} --silent --output /dev/null https://localhost:8443`
+STATUS=$(curl -k --write-out %{http_code} --silent --output /dev/null https://localhost:$JENKINS_PORT)
 
 if [ ! "200" == "$STATUS" ]; then
     exit 1


### PR DESCRIPTION
Hard-coded mapped ports are probably the main blocker to running multiple copies of devspace on the same host. This removes the mapping, leaving docker to dynamically map the ports.

To run multiple copies of devspace you must use the docker-compose `-p, --project-name NAME` flag to distinguish between multiple copies. e.g.
```
$ docker-compose -p altspace up
...

# Get the published jenkins web port:
$ docker-compose -p altspace port nginxjenkins 443
0.0.0.0:32805
```
which means altspace should be accessible on https://docker-host:32805/

See https://github.com/openmicroscopy/devspace/issues/73