### PR TITLE
run diagnostics after starting service

### DIFF
--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -122,6 +122,7 @@ BUILD_ID=DONT_KILL_ME $OMERO_DIST/bin/omero admin start
 
 # WAIT FOR OMERO TO START UP AND ACCEPT CONNECTIONS
 $OMERO_DIST/bin/omero admin waitup
+$OMERO_DIST/bin/omero admin diagnostics
 
 deactivate</command>
     </hudson.tasks.Shell>

--- a/home/jobs/OMERO-test-integration/config.xml
+++ b/home/jobs/OMERO-test-integration/config.xml
@@ -103,7 +103,7 @@ pip install -r $OMERO_DIST/share/web/requirements-py27-nginx.txt
 # START OMERO
 BUILD_ID=DONT_KILL_ME $OMERO_DIST/bin/omero admin start
 $OMERO_DIST/bin/omero admin waitup
-
+$OMERO_DIST/bin/omero admin diagnostics
 
 # RUN TESTS
 export OMERO_SESSION_DIR=/tmp/$JOB_NAME/$BUILD_NUMBER

--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -87,6 +87,7 @@ $OMERO_DIST/bin/omero config set omero.web.wsgi_args -- &apos;--log-level=DEBUG 
 $OMERO_DIST/bin/omero config set omero.web.application_server.host 0.0.0.0
 
 BUILD_ID=DONT_KILL_ME $OMERO_DIST/bin/omero web start
+$OMERO_DIST/bin/omero web diagnostics
 
 deactivate
       </command>

--- a/server/run.sh
+++ b/server/run.sh
@@ -6,6 +6,7 @@ function shut_down() {
 
 /tmp/jenkins-slave.sh &
 /home/omero/workspace/OMERO-server/OMERO.server/bin/omero admin start
+/home/omero/workspace/OMERO-server/OMERO.server/bin/omero admin diagnostics
 
 trap "shut_down" SIGKILL SIGTERM SIGHUP SIGINT EXIT
 

--- a/slave/run.sh
+++ b/slave/run.sh
@@ -6,6 +6,7 @@ function shut_down() {
 
 /tmp/jenkins-slave.sh &
 /home/omero/workspace/OMERO-test-integration/src/dist/bin/omero admin start
+/home/omero/workspace/OMERO-test-integration/src/dist/bin/omero admin diagnostics
 
 trap "shut_down" SIGKILL SIGTERM SIGHUP SIGINT EXIT
 


### PR DESCRIPTION
Sometimes when there is an issue with CI not working it is helpful to have diagnostics available in the console log for the job that should have started a related service. This PR adds some of those diagnostics runs.