### PR TITLE
Move the OMERO.server data directory out of the workspace

### DIFF
--- a/home/jobs/OMERO-server/config.xml
+++ b/home/jobs/OMERO-server/config.xml
@@ -18,8 +18,8 @@
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>DATA_DIR</name>
-          <description>Default is $WORKSPACE/data</description>
-          <defaultValue>$WORKSPACE/data</defaultValue>
+          <description>Default is $HOME/omero-server-data</description>
+          <defaultValue>$HOME/omero-server-data</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -54,6 +54,7 @@ fi
 
 if [ &quot;$PURGE_DATA&quot; = &quot;true&quot; ]; then
     dropdb -h $OMERO_DB_HOST -U $OMERO_DB_USER $OMERO_DB_NAME || echo &quot;First run or already exists&quot;
+    rm -rf $OMERO_DATA_DIR
 else
     echo &quot;Skipping PURGE_DATA:CleanDbAndRepo&quot;
 fi


### PR DESCRIPTION
See https://trello.com/c/3EQjb1Jx/28-bug-devspace-problem-with-data-preservation

The original layout caused the data directory to be unconditionally removed
independently of the value of PURGE_DATA.
This change modifies the default value of OMERO_DATA_DIR to be outside the
job workspace and ties the data directory cleanup step to the PURGE_DATA value
alongside the database drop step.

Can be considered as a candidate for `0.7.0` or even as a patch release e.g. `0.7.1` as this is fixing a bug.