### PR TITLE
Plugins update

### DIFF
--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -1,5 +1,5 @@
-swarm:3.9
-git:3.7.0
+swarm:3.10
+git:3.8.0
 git-client:2.7.1
 git-server:1.7
 mailer:1.20
@@ -38,26 +38,26 @@ run-condition:1.0
 repository:1.3
 maven-plugin:3.1
 apache-httpcomponents-client-4-api:4.5.3-2.1
-jsch:0.1.54.1
+jsch:0.1.54.2
 
 # Optional
 parameterized-trigger:2.35.2
-subversion:2.10.2
+subversion:2.10.3
 token-macro:2.3
-promoted-builds:2.31.1
+promoted-builds:3.0
 cloudbees-folder:6.3
 
 # Workflow
 # See: https://github.com/jenkinsci/workflow-plugin/blob/master/demo/plugins.txt
-durable-task:1.17
+durable-task:1.18
 ace-editor:1.1
 jquery-detached:1.2.1
 workflow-aggregator:2.5
-workflow-api:2.25
+workflow-api:2.26
 workflow-basic-steps:2.6
 workflow-cps:2.45
 workflow-cps-global-lib:2.9
-workflow-durable-task-step:2.18
+workflow-durable-task-step:2.19
 workflow-job:2.17
 workflow-multibranch:2.17
 workflow-remote-loader:1.4
@@ -97,4 +97,4 @@ jobConfigHistory:2.18
 rundeck:3.6.4
 
 # ldap
-ldap:1.19
+ldap:1.20

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.1
+FROM openmicroscopy/devslave-c7:0.4.0
 
 MAINTAINER OME
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.1
+FROM openmicroscopy/devslave-c7:0.4.0
 
 MAINTAINER OME
 

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.1
+FROM openmicroscopy/devslave-c7:0.4.0
 
 MAINTAINER OME
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.3.1
+FROM openmicroscopy/devslave-c7:0.4.0
 
 MAINTAINER OME
 


### PR DESCRIPTION
- upgrades plugins to includes latest security fixes - see https://jenkins.io/security/advisory/2018-02-26/
- consumes `openmicroscopy:devslave:0.4.0`

Fixes #92 