### PR TITLE
Update versions in configuration files

### DIFF
--- a/home/hudson.plugins.git.GitTool.xml
+++ b/home/hudson.plugins.git.GitTool.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<hudson.plugins.git.GitTool_-DescriptorImpl plugin="git-client@2.2.1">
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.plugins.git.GitTool_-DescriptorImpl plugin="git-client@2.7.2">
   <installations class="hudson.plugins.git.GitTool-array">
     <hudson.plugins.git.GitTool>
       <name>Default</name>

--- a/home/hudson.tasks.Ant.xml
+++ b/home/hudson.tasks.Ant.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<hudson.tasks.Ant_-DescriptorImpl plugin="ant@1.2">
+<?xml version='1.1' encoding='UTF-8'?>
+<hudson.tasks.Ant_-DescriptorImpl plugin="ant@1.8">
   <installations>
     <hudson.tasks.Ant_-AntInstallation>
       <name>Ant 1.9</name>

--- a/home/hudson.tasks.Maven.xml
+++ b/home/hudson.tasks.Maven.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <hudson.tasks.Maven_-DescriptorImpl>
   <installations>
     <hudson.tasks.Maven_-MavenInstallation>

--- a/home/jenkins.mvn.GlobalMavenConfig.xml
+++ b/home/jenkins.mvn.GlobalMavenConfig.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <jenkins.mvn.GlobalMavenConfig>
   <settingsProvider class="jenkins.mvn.DefaultSettingsProvider"/>
   <globalSettingsProvider class="jenkins.mvn.DefaultGlobalSettingsProvider"/>

--- a/home/jobs/BIOFORMATS-build/config.xml
+++ b/home/jobs/BIOFORMATS-build/config.xml
@@ -1,5 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<matrix-project plugin="matrix-project@1.12">
+<?xml version='1.1' encoding='UTF-8'?>
+<matrix-project plugin="matrix-project@1.13">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -18,6 +18,7 @@
           <name>PUSH_BRANCH</name>
           <description></description>
           <defaultValue>SPACEBRANCH_merge_trigger</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>SKIP_DOCS_VALIDATION</name>
@@ -27,11 +28,11 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.8.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/snoopycrimecop/bio-formats-build</url>
+        <url>git://github.com/SPACEUSER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/BIOFORMATS-docs/config.xml
+++ b/home/jobs/BIOFORMATS-docs/config.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description></description>
@@ -10,6 +10,7 @@
           <name>PUSH_BRANCH</name>
           <description></description>
           <defaultValue>SPACEBRANCH_merge_trigger</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
           <name>SKIP_DOCS_VALIDATION</name>
@@ -19,11 +20,11 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.8.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/snoopycrimecop/bio-formats-build</url>
+        <url>git://github.com/SPACEUSER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>

--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -1,10 +1,10 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties/>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.3.2">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -13,7 +13,7 @@
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>SPACENAME_merge_trigger</name>
+        <name>SPACEBRANCH_merge_trigger</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>

--- a/home/jobs/BIOFORMATS-push/config.xml
+++ b/home/jobs/BIOFORMATS-push/config.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description></description>
@@ -10,6 +10,7 @@
           <name>MERGE_OPTIONS</name>
           <description></description>
           <defaultValue>--no-ask --reset</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>STATUS</name>
@@ -26,16 +27,18 @@
           <name>PUSH_BRANCH</name>
           <description></description>
           <defaultValue>SPACEBRANCH_merge_trigger</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>BASE_BRANCH</name>
           <description></description>
           <defaultValue>master</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.8.0">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>

--- a/home/jobs/OMERO-build/config.xml
+++ b/home/jobs/OMERO-build/config.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description></description>
@@ -13,7 +13,7 @@
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.3.2">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -73,6 +73,6 @@ source docs/hudson/OMERO.sh
     </hudson.tasks.ArtifactArchiver>
   </publishers>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.10"/>
   </buildWrappers>
 </project>

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -17,7 +17,7 @@
         <hudson.model.StringParameterDefinition>
           <name>MERGE_COMMAND</name>
           <description></description>
-          <defaultValue>merge SPACENAME --no-ask --reset</defaultValue>
+          <defaultValue>merge develop --no-ask --reset</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>

--- a/home/jobs/OMERO-docs/config.xml
+++ b/home/jobs/OMERO-docs/config.xml
@@ -17,7 +17,7 @@
         <hudson.model.StringParameterDefinition>
           <name>MERGE_COMMAND</name>
           <description></description>
-          <defaultValue>merge develop --no-ask --reset</defaultValue>
+          <defaultValue>merge SPACEBRANCH --no-ask --reset</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>

--- a/home/jobs/OMERO-push/config.xml
+++ b/home/jobs/OMERO-push/config.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
   <description></description>
@@ -9,7 +9,8 @@
         <hudson.model.StringParameterDefinition>
           <name>MERGE_COMMAND</name>
           <description></description>
-          <defaultValue>merge SPACENAME --no-ask --reset --shallow</defaultValue>
+          <defaultValue>merge SPACEBRANCH --no-ask --reset --shallow</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.ChoiceParameterDefinition>
           <name>STATUS</name>
@@ -26,11 +27,12 @@
           <name>PUSH_BRANCH</name>
           <description></description>
           <defaultValue>SPACEBRANCH_merge_trigger</defaultValue>
+          <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.3.2">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.9.1">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -77,6 +79,6 @@ $HOME/.local/bin/scc $MERGE_COMMAND -S $STATUS --push $PUSH_BRANCH</command>
   </builders>
   <publishers/>
   <buildWrappers>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.8"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.8.10"/>
   </buildWrappers>
 </project>

--- a/home/org.jenkinsci.plugins.gitclient.JGitTool.xml
+++ b/home/org.jenkinsci.plugins.gitclient.JGitTool.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<org.jenkinsci.plugins.gitclient.JGitTool_-DescriptorImpl plugin="git-client@1.19.0">
+<?xml version='1.1' encoding='UTF-8'?>
+<org.jenkinsci.plugins.gitclient.JGitTool_-DescriptorImpl plugin="git-client@2.7.2">
   <installations class="hudson.plugins.git.GitTool-array"/>
 </org.jenkinsci.plugins.gitclient.JGitTool_-DescriptorImpl>


### PR DESCRIPTION
Follow-up of #99, this propagates the automatic configuration changes performed when running the individual jobs using the updated Jenkins. This allows the diff between a running devspace and the repository to be limited to the production configuration (environment and branch setup)

Changes:

- individual version bumps should correspond to the latest plugins update
- also fix a few harcoded branches/users

Requires mostly code review and should be safe to include in a `0.9.0` tag. Alternatively, happy to cut `0.9.0` from the current `master` and call this `0.9.1`