### PR TITLE
Add a top-level commit to bio-formats-build bumping submodule version

### DIFF
--- a/home/jobs/BIOFORMATS-push/config.xml
+++ b/home/jobs/BIOFORMATS-push/config.xml
@@ -85,7 +85,7 @@ MERGE_OPTIONS=&quot;$MERGE_OPTIONS -S $STATUS&quot;
 cd bio-formats-build
 
 echo &quot;Merge base repository (no submodule updates)&quot;
-scc merge -v $MERGE_OPTIONS --shallow $BASE_BRANCH
+scc merge $MERGE_OPTIONS --shallow master
 
 # Update any changed submodules
 git submodule sync
@@ -93,7 +93,7 @@ git submodule update --remote --recursive
 
 echo &quot;Merge all submodules using repository configuration:&quot;
 cat &quot;scripts/repositories.yml&quot;
-scc merge -v &quot;--repository-config=$(pwd)/scripts/repositories.yml&quot; $MERGE_OPTIONS --update-gitmodules --push $PUSH_BRANCH $BASE_BRANCH
+scc merge &quot;--repository-config=$(pwd)/scripts/repositories.yml&quot; $MERGE_OPTIONS --update-gitmodules --push $PUSH_BRANCH master
 
 echo &quot;Update maven component versions&quot;
 update-versions
@@ -105,6 +105,11 @@ git submodule foreach &quot;git commit -m &apos;Update component versions&apos; 
 echo &quot;Push all branches&quot;
 user=$(git config github.user)
 git submodule foreach &quot;git push -f git@github.com:$user/&quot;&apos;${path}.git&apos;&quot; HEAD:$PUSH_BRANCH&quot;
+
+echo &quot;Commit all component version changes&quot;
+git add -u
+git commit -m &apos;Update component versions&apos; || true
+
 git push -f git@github.com:$user/bio-formats-build.git HEAD:$PUSH_BRANCH</command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
The current logic of the BIOFORMATS-push works as follows:
- merge all PRs against top-level bio-formats-build
- merge all PRs against submodules
- bump submodules in top-level repository
- bump the component versions across submodules
- push submodule and top-level branches

Although this works fine, this means that the top-level commit was pointing to the submodule commit prior to the component versions bump and resulted in the absence of coupling of the components.
This change should include an additional top-level commit implementing this coupling for downstream jobs.