### PR TITLE
Run the tests in a different locale weekly

### DIFF
--- a/home/jobs/BIOFORMATS-test-folder/config.xml
+++ b/home/jobs/BIOFORMATS-test-folder/config.xml
@@ -43,6 +43,9 @@
     echo &quot;EARLY EXIT&quot;
     exit 0
 fi
+if [ $(date +%u) -gt 6 ]; then
+    DOCKER_ARGS="$DOCKER_ARGS -Duser.language=fr -Duser.country=FR"
+fi
 sudo docker run --rm --name ${JOB_NAME}_${BUILD_NUMBER}_SPACENAME -v $DATA_PATH:/opt/data -v $CONFIG_PATH:/opt/config openmicroscopy/bioformats:SPACENAME $DOCKER_ARGS</command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
This feature had been discussed previously in https://trello.com/c/6ZEbxkDE/123-test-in-non-english-locale and implemented via a weekly trigger job. With the new distributed tests, this change uses the indexed day of the week to override the default locale and run the tests in a French locale on Sundays.

This has been applied to the east-ci devspace. To test this PR, review the output of https://web-proxy.openmicroscopy.org/east-ci/job/BIOFORMATS-test-repo/ on Monday and check `user.language` and `user.country` are correctly set to `fr` and `FR`.

/cc @mtbc 