### PR TITLE
Jenkins security updates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbesson/devslave-c7:0.5.0
+FROM openmicroscopy/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.4.0
+FROM sbesson/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/home/config.xml
+++ b/home/config.xml
@@ -3,7 +3,7 @@
   <disabledAdministrativeMonitors>
     <string>jenkins.security.s2m.MasterKillSwitchWarning</string>
   </disabledAdministrativeMonitors>
-  <version>2.121.2</version>
+  <version>2.138.1</version>
   <installStateName>RESTART</installStateName>
   <numExecutors>0</numExecutors>
   <mode>NORMAL</mode>

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.121.2
+FROM jenkins/jenkins:2.138.1
 MAINTAINER OME
 
 # Temp fix robot test results

--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -1,4 +1,4 @@
-swarm:3.13
+swarm:3.14
 git:3.9.1
 git-client:2.7.3
 git-server:1.7
@@ -7,13 +7,13 @@ scm-api:2.2.7
 matrix-project:1.13
 ssh-credentials:1.14
 credentials:2.1.18
-script-security:1.44
-role-strategy:2.8.1
+script-security:1.46
+role-strategy:2.9.0
 matrix-auth:2.3
 icon-shim:2.0.3
 authentication-tokens:1.3
 
-junit:1.24
+junit:1.26.1
 testng-plugin:1.15
 
 jdk-tool:1.1
@@ -23,16 +23,16 @@ artifactory:2.16.2
 ant:1.8
 gradle:1.29
 ivy:1.28
-config-file-provider:2.18
+config-file-provider:3.2
 
 copyartifact:1.41
 
 branch-api:2.0.20
 mapdb-api:1.0.9.0
 display-url-api:2.2.0
-structs:1.14
+structs:1.15
 conditional-buildstep:1.3.6
-run-condition:1.0
+run-condition:1.2
 
 
 # As a repository
@@ -43,28 +43,28 @@ jsch:0.1.54.2
 
 # Optional
 parameterized-trigger:2.35.2
-subversion:2.11.1
+subversion:2.12.1
 token-macro:2.5
 promoted-builds:3.2
 cloudbees-folder:6.5.1
 
 # Workflow
 # See: https://github.com/jenkinsci/workflow-plugin/blob/master/demo/plugins.txt
-durable-task:1.22
+durable-task:1.26
 ace-editor:1.1
 jquery-detached:1.2.1
 workflow-aggregator:2.5
 workflow-api:2.29
-workflow-basic-steps:2.9
-workflow-cps:2.54
-workflow-cps-global-lib:2.9
-workflow-durable-task-step:2.19
-workflow-job:2.23
+workflow-basic-steps:2.11
+workflow-cps:2.56
+workflow-cps-global-lib:2.11
+workflow-durable-task-step:2.22
+workflow-job:2.25
 workflow-multibranch:2.20
 workflow-remote-loader:1.4
 workflow-scm-step:2.6
 workflow-step-api:2.16
-workflow-support:2.19
+workflow-support:2.20
 
 pipeline-rest-api:2.10
 pipeline-stage-view:2.10
@@ -73,11 +73,11 @@ pipeline-build-step:2.7
 pipeline-input-step:2.8
 pipeline-milestone-step:1.3.1
 pipeline-graph-analysis:1.7
-pipeline-model-definition:1.3
-pipeline-model-api:1.3.1
+pipeline-model-definition:1.3.2
+pipeline-model-api:1.3.2
 pipeline-model-declarative-agent:1.1.1
-pipeline-model-extensions:1.3.1
-pipeline-stage-tags-metadata:1.3
+pipeline-model-extensions:1.3.2
+pipeline-stage-tags-metadata:1.3.2
 jackson2-api:2.8.11.3
 
 docker-workflow:1.17
@@ -89,12 +89,12 @@ handlebars:1.1.1
 momentjs:1.1.1
 
 # Robot
-robot:1.6.4
+robot:1.6.5
 
 # Utils
 greenballs:1.15
 timestamper:1.8.10
-jobConfigHistory:2.18
+jobConfigHistory:2.18.2
 rundeck:3.6.4
 
 # ldap

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbesson/devslave-c7:0.5.0
+FROM openmicroscopy/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.4.0
+FROM sbesson/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbesson/devslave-c7:0.5.0
+FROM openmicroscopy/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.4.0
+FROM sbesson/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbesson/devslave-c7:0.5.0
+FROM openmicroscopy/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.4.0
+FROM sbesson/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -3,7 +3,7 @@ FROM openmicroscopy/devslave-c7:0.5.0
 MAINTAINER OME
 
 ARG JAVAVER=openjdk18
-ARG ICEVER=ice36
+ARG ICEVER=ice36-devel
 
 # skip some omero-install
 RUN echo 'export container=docker' > /etc/profile.d/docker.sh

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM sbesson/devslave-c7:0.5.0
+FROM openmicroscopy/devslave-c7:0.5.0
 
 MAINTAINER OME
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/devslave-c7:0.4.0
+FROM sbesson/devslave-c7:0.5.0
 
 MAINTAINER OME
 


### PR DESCRIPTION
This PR performs a round of upgrade of Jenkins LTS (to 2.138.1) and of the installed plugins to include the latest security fixes. See https://jenkins.io/security/advisory/2018-08-15/ and https://jenkins.io/security/advisory/2018-09-25/ for more details.

As Jenkins LTS 2.138.1 deprecates the protocols used for connecting the Docker-base slaves (see https://travis-ci.org/openmicroscopy/devspace/builds/435333853?utm_source=github_status&utm_medium=notification for an example of failing builds), with minimal changes to the current infrastructure, the Jenkins upgrade requires the changes proposed in https://github.com/openmicroscopy/devslave-c7-docker/pull/16 which also upgrade the version of the Swarm Client JAR  as per the [Remoting upgrade guidelines](https://jenkins.io/doc/upgrade-guide/2.121/#remoting-update).

f8084d4 includes a custom image built with https://github.com/openmicroscopy/devslave-c7-docker/pull/16 and should show that clients successfully connects to Jenkins in Travis. Once this has been reviewed, merged and a new upstream image deployed to DockerHub, this should be replaced by a commit consuming `openmicroscopy/devslave-c7:0.5.0`.