### PR TITLE
Add omero-server-data to .dockerignore

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,3 +1,4 @@
+omero-server-data
 workspace
 .jenkins
 .local


### PR DESCRIPTION
Tested while upgrading a devspace with #106.

Now that `omero-server-data` is preserved within the `server/` directory, this should prevent the `docker-compose build` operation from including this folder in the temporary archive created during rebuild. In addition to the space gained, this operation led to `IOError`s of type

```
IOError: Can not access file in context: ...
```