### PR TITLE
Upgrade Jenkins LTS to version 2.150.1

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.138.1
+FROM jenkins/jenkins:2.150.1
 MAINTAINER OME
 
 # Temp fix robot test results

--- a/jenkins/plugins.txt
+++ b/jenkins/plugins.txt
@@ -1,13 +1,13 @@
 swarm:3.14
 git:3.9.1
-git-client:2.7.3
+git-client:2.7.4
 git-server:1.7
-mailer:1.21
-scm-api:2.2.7
+mailer:1.22
+scm-api:2.3.0
 matrix-project:1.13
 ssh-credentials:1.14
 credentials:2.1.18
-script-security:1.46
+script-security:1.49
 role-strategy:2.9.0
 matrix-auth:2.3
 icon-shim:2.0.3
@@ -20,24 +20,24 @@ jdk-tool:1.1
 javadoc:1.4
 
 artifactory:2.16.2
-ant:1.8
+ant:1.9
 gradle:1.29
 ivy:1.28
-config-file-provider:3.2
+config-file-provider:3.4.1
 
 copyartifact:1.41
 
-branch-api:2.0.20
+branch-api:2.1.1
 mapdb-api:1.0.9.0
-display-url-api:2.2.0
-structs:1.15
+display-url-api:2.3.0
+structs:1.17
 conditional-buildstep:1.3.6
 run-condition:1.2
 
 
 # As a repository
 repository:1.3
-maven-plugin:3.1.2
+maven-plugin:3.2
 apache-httpcomponents-client-4-api:4.5.5-3.0
 jsch:0.1.54.2
 
@@ -46,25 +46,26 @@ parameterized-trigger:2.35.2
 subversion:2.12.1
 token-macro:2.5
 promoted-builds:3.2
-cloudbees-folder:6.5.1
+cloudbees-folder:6.7
 
 # Workflow
 # See: https://github.com/jenkinsci/workflow-plugin/blob/master/demo/plugins.txt
-durable-task:1.26
+durable-task:1.28
 ace-editor:1.1
 jquery-detached:1.2.1
-workflow-aggregator:2.5
-workflow-api:2.29
-workflow-basic-steps:2.11
-workflow-cps:2.56
-workflow-cps-global-lib:2.11
-workflow-durable-task-step:2.22
-workflow-job:2.25
+lockable-resources:2.3
+workflow-aggregator:2.6
+workflow-api:2.33
+workflow-basic-steps:2.13
+workflow-cps:2.61
+workflow-cps-global-lib:2.7
+workflow-durable-task-step:2.26
+workflow-job:2.29
 workflow-multibranch:2.20
 workflow-remote-loader:1.4
-workflow-scm-step:2.6
+workflow-scm-step:2.7
 workflow-step-api:2.16
-workflow-support:2.20
+workflow-support:2.23
 
 pipeline-rest-api:2.10
 pipeline-stage-view:2.10
@@ -73,17 +74,17 @@ pipeline-build-step:2.7
 pipeline-input-step:2.8
 pipeline-milestone-step:1.3.1
 pipeline-graph-analysis:1.7
-pipeline-model-definition:1.3.2
-pipeline-model-api:1.3.2
+pipeline-model-definition:1.3.3
+pipeline-model-api:1.3.3
 pipeline-model-declarative-agent:1.1.1
-pipeline-model-extensions:1.3.2
-pipeline-stage-tags-metadata:1.3.2
-jackson2-api:2.8.11.3
+pipeline-model-extensions:1.3.3
+pipeline-stage-tags-metadata:1.3.3
+jackson2-api:2.9.7.1
 
 docker-workflow:1.17
 docker-commons:1.13
 
-credentials-binding:1.16
+credentials-binding:1.17
 plain-credentials:1.4
 handlebars:1.1.1
 momentjs:1.1.1
@@ -94,7 +95,7 @@ robot:1.6.5
 # Utils
 greenballs:1.15
 timestamper:1.8.10
-jobConfigHistory:2.18.2
+jobConfigHistory:2.19
 rundeck:3.6.4
 
 # ldap


### PR DESCRIPTION
See https://jenkins.io/security/advisory/2018-12-05/

Also upgrades all Jenkins plugins to their latest version including a few security fixes.