### PR TITLE
Improve the control of the PostgreSQL and NGINX image versions

### DIFF
--- a/.env
+++ b/.env
@@ -19,5 +19,9 @@ OMERO_SERVER_TCP=
 REPO_CURATED=/tmp/curated
 REPO_CONFIG=/tmp/config
 
+# Variables for controlling external dependencies versions
+POSTGRES_VERSION=10
+NGINX_VERSION=1.10
+
 # Other variables
 DOCKER_EXECUTORS=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         command: 'true'
 
     pg:
-        image: postgres:10
+        image: postgres:${POSTGRES_VERSION}
         networks:
             - omero-network
         volumes:
@@ -101,7 +101,7 @@ services:
             - "${NGINX_SSL_PORT}443"
 
     nginxjenkins:
-        image: nginx:1.10
+        image: nginx:${NGINX_VERSION}
         networks:
             - omero-network
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         command: 'true'
 
     pg:
-        image: postgres
+        image: postgres:10
         networks:
             - omero-network
         volumes:


### PR DESCRIPTION
Following #108, a devspace was upgraded and images rebuilt. In the meantime the latest `postgres` image was pulled leading to 

```
[sbesson@idr1-slot2 east-ci]$ docker logs 7381d435532f
2018-12-05 17:19:59.292 UTC [1] FATAL:  database files are incompatible with server
2018-12-05 17:19:59.292 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 10, which is not compatible with this version 11.0 (Debian 11.0-1.pgdg90+2).
```

Given the

- d19db49 pins the postgresql image to a major version rather than following the `latest` tag 
- f44db2f make the image version modifiable via `.env` and applies the same logic to `nginx`

Proposed tag: `0.10.2`