### PR TITLE
Run Nexus as part of devspace

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ JENKINS_BASE=http://jenkins:8080
 WEB_PREFIX=/web
 
 # Variables for influencing dynamic ports
+NGINXJENKINS_HTTP_PORT=
 NGINXJENKINS_SSL_PORT=
 NGINX_PORT=
 NGINX_SSL_PORT=
@@ -21,7 +22,7 @@ REPO_CONFIG=/tmp/config
 
 # Variables for controlling external dependencies versions
 POSTGRES_VERSION=10
-NGINX_VERSION=1.10
+NGINX_VERSION=1.15
 
 # Other variables
 DOCKER_EXECUTORS=10

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Start and configure:
         auth_basic "Restricted";
         auth_basic_user_file /etc/nginx/conf.d/passwdfile;
 
+*   [Optional] Create the `maven-internal` Nexus repository:
+
+        $ docker-compose exec nexus /nexus-data/createRepoMavenInternal.sh
+
 
 ## Deploy on OpenStack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
             - ./jenkins/conf.d:/etc/nginx/conf.d
             - ./jenkins/sslcert:/etc/nginx/ssl
         ports:
+            - "${NGINXJENKINS_HTTP_PORT}80"
             - "${NGINXJENKINS_SSL_PORT}443"
 
     redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,22 @@ services:
             - REPO_CURATED
             - REPO_CONFIG
 
+    nexus:
+        image: sonatype/nexus3
+        user: ${USER_ID}
+        networks:
+            - omero-network
+        volumes:
+            - ./nexus-data:/nexus-data
+        ports:
+            # TODO: Remove all ports when we can configure nexus automatically
+            - 8081
+        environment:
+            # Needed so nexus can be proxied under /nexus
+            # Note additional configuration to set the full base url in Nexus
+            # may be required if running on a non-standard http/https port
+            NEXUS_CONTEXT: nexus
+
 networks:
     omero-network:
         # If devspace fails and your network has a non-standard MTU this may

--- a/jenkins/conf.d/jenkins.conf
+++ b/jenkins/conf.d/jenkins.conf
@@ -39,5 +39,9 @@ server {
         proxy_set_header        X-Forwarded-Proto   $scheme;
         proxy_set_header        X-Forwarded-Port    $server_port;
     }
+    # Currently using default credentials so block logins
+    location /nexus/service/rapture/session {
+            deny all;
+    }
 
 }

--- a/jenkins/conf.d/jenkins.conf
+++ b/jenkins/conf.d/jenkins.conf
@@ -6,10 +6,10 @@ upstream jenkins_app {
 
 server {
 
+    listen              80;
     listen              443 default ssl;
     server_name         $hostname;
 
-    ssl on;
     ssl_certificate     /etc/nginx/ssl/server.crt;
     ssl_certificate_key /etc/nginx/ssl/server.key;
     ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;  # don’t use SSLv3 ref: POODLE
@@ -37,6 +37,7 @@ server {
         proxy_set_header        X-Real-IP           $remote_addr;
         proxy_set_header        X-Forwarded-For     $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Proto   $scheme;
+        proxy_set_header        X-Forwarded-Port    $server_port;
     }
 
 }

--- a/jenkins/conf.d/jenkins.conf
+++ b/jenkins/conf.d/jenkins.conf
@@ -27,4 +27,16 @@ server {
         proxy_pass              http://jenkins_app;
 
     }
+
+    ## Reference:
+    ## https://help.sonatype.com/repomanager3/installation/run-behind-a-reverse-proxy
+    ## https://stackoverflow.com/a/48703466/8062212
+    location /nexus {
+        proxy_pass              http://nexus:8081/nexus;      
+        proxy_set_header        Host                $host:$server_port;
+        proxy_set_header        X-Real-IP           $remote_addr;
+        proxy_set_header        X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto   $scheme;
+    }
+
 }

--- a/nexus-data/.gitignore
+++ b/nexus-data/.gitignore
@@ -1,0 +1,3 @@
+*/
+lock
+port

--- a/nexus-data/createRepoMavenInternal.json
+++ b/nexus-data/createRepoMavenInternal.json
@@ -1,0 +1,5 @@
+{
+  "name": "createRepoMavenInternal",
+  "type": "groovy",
+  "content": "import org.sonatype.nexus.blobstore.api.BlobStoreManager; import org.sonatype.nexus.repository.maven.LayoutPolicy; import org.sonatype.nexus.repository.storage.WritePolicy; import org.sonatype.nexus.repository.maven.VersionPolicy; repository.createMavenHosted('maven-internal', BlobStoreManager.DEFAULT_BLOBSTORE_NAME, true, VersionPolicy.MIXED, WritePolicy.ALLOW_ONCE, LayoutPolicy.STRICT)"
+}

--- a/nexus-data/createRepoMavenInternal.sh
+++ b/nexus-data/createRepoMavenInternal.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Based on
+# https://github.com/sonatype-nexus-community/nexus-scripting-examples/tree/master/simple-shell-example
+set -eux
+NEXUS=http://localhost:8081/nexus
+curl -f -u admin:admin123 --header "Content-Type: application/json" "$NEXUS/service/rest/v1/script/" -d @/nexus-data/createRepoMavenInternal.json
+curl -X POST -u admin:admin123 --header "Content-Type: text/plain" "$NEXUS/service/rest/v1/script/createRepoMavenInternal/run"
+


### PR DESCRIPTION
Nexus can be accessed at `http://jenkinsnginx/nexus/`. If Nginx is forwarded to a non-standard port Nexus probably won't work without additional configuration to pass the full external URL including port, it's easier on a single host to set
```
NGINXJENKINS_HTTP_PORT=80:
NGINXJENKINS_HTTPS_PORT=443:
```

Currently the `maven-internal` repository must be created manually after nexus has started:
```
docker-compose exec nexus /nexus-data/createRepoMavenInternal.sh
```

Nexus is using the default credentials so at present external login via nginx is blocked