### PR TITLE
Use template generation for new pipeline jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Creating a new job called `JOBNAME` should then be as easy as:
 
 Replace the following strings in `home/jobs/JOBNAME/config.xml`:
 - `[DESCRIPTION]`: Job description, recommended
-- `[REPOSITORY]`: GitHub username/repository
+- `[REPOSITORY]`: GitHub username (typically either `opemicroscopy` or `SPACEUSER`) and repository
 - `Jenkinsfile`: If you have multiple `Jenkinsfile`s change this to the required file
 
 Alternatively create a new Pipeline job in the Jenkins web-interface in the usual way.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,21 @@ If you do not have some of the repositories forked, you will need to remove the 
 of jobs to run either from the Trigger job [configuration](home/jobs/Trigger/config.xml) 
 or directly from the Jenkins UI i.e. ``Trigger > Configure``.
 
+# New jobs
+
+It is recommended that new jobs should be defined using [Jenkinsfile pipelines](https://jenkins.io/doc/book/pipeline/jenkinsfile/) in the target repository as this makes it easier to maintain jobs.
+Creating a new job called `JOBNAME` should then be as easy as:
+
+    mkdir home/jobs/JOBNAME
+    cp TEMPLATE-pipeline-job-config.xml home/jobs/JOBNAME/config.xml
+
+Replace the following strings in `home/jobs/JOBNAME/config.xml`:
+- `[DESCRIPTION]`: Job description, recommended
+- `[REPOSITORY]`: GitHub username/repository
+- `Jenkinsfile`: If you have multiple `Jenkinsfile`s change this to the required file
+
+Alternatively create a new Pipeline job in the Jenkins web-interface in the usual way.
+
 # Default packages used
 
 | Name       | Version       | Optional                           |

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Creating a new job called `JOBNAME` should then be as easy as:
 
 Replace the following strings in `home/jobs/JOBNAME/config.xml`:
 - `[DESCRIPTION]`: Job description, recommended
-- `[REPOSITORY]`: GitHub username (typically either `opemicroscopy` or `SPACEUSER`) and repository
+- `[REPOSITORY]`: GitHub username (typically either `openmicroscopy` or `SPACEUSER`) and repository
 - `Jenkinsfile`: If you have multiple `Jenkinsfile`s change this to the required file
 
 Alternatively create a new Pipeline job in the Jenkins web-interface in the usual way.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Running Devspace requires access to SSH and Git configuration files used for fet
 Devspace code depends on the following repositories:
 
 * [OMERO install](https://github.com/ome/omero-install/)
-* [devslave-c7-docker](https://github.com/openmicroscopy/devslave-c7-docker) 
+* [devslave-c7-docker](https://github.com/openmicroscopy/devslave-c7-docker)
 
 and for OpenStack (optional)
 
@@ -44,7 +44,7 @@ The following instructions explain how to deploy a devspace on a Docker host.
         $ pip install docker-compose
 
 *   Create a directory ``/data/username`` and change ownership:
-    
+
         $ sudo mkdir /data/username
         $ sudo chown username /data/username
 
@@ -101,7 +101,7 @@ Start and configure:
 
 *   [Optional] Turn on Basic HTTP authentication for Jenkins
 
-        sudo htpasswd -c jenkins/conf.d/passwdfile nginx 
+        sudo htpasswd -c jenkins/conf.d/passwdfile nginx
 
     and update `jenkins/conf.d/jenkins.conf`:
 
@@ -121,8 +121,8 @@ The OpenStack and SSH and Git following steps are only need to be done the first
 #### OpenStack configuration
 
 * Log into [OpenStack](https://pony.openmicroscopy.org)
-* Register a key: 
-   * Go to the ``Access & Security`` tab 
+* Register a key:
+   * Go to the ``Access & Security`` tab
    * Click on ``Key Pairs`` and then on ``Import Key Pair``
    * Copy the content of the public key you use to access our resources e.g. ``id_rsa.pub``
    * The name you used is referred below as ``your_openstack_key``
@@ -241,7 +241,7 @@ Ports to access the various services are dynamically assigned. You will have to 
 
 * The port to access OMERO.web is obtained by running:
 
-       docker-compose port nginx 80 
+       docker-compose port nginx 80
 
     * The command will generate a similar output that the one above
 
@@ -249,16 +249,16 @@ Ports to access the various services are dynamically assigned. You will have to 
             WARNING: The USER_ID variable is not set. Defaulting to a blank string.
             0.0.0.0:xxxx
 
-        where ``xxxx`` is the assigned port ``$WEB_PORT`` 
+        where ``xxxx`` is the assigned port ``$WEB_PORT``
 
     * OMERO.web will be available at
 
-            http://devspace_openstack_ip:$WEB_PORT/web 
+            http://devspace_openstack_ip:$WEB_PORT/web
 
 
 * The port to access OMERO.insight or OMERO.cli is obtained by running:
 
-       docker-compose port omero 4064 
+       docker-compose port omero 4064
 
     * The command will generate a similar output that the one above
 
@@ -266,7 +266,7 @@ Ports to access the various services are dynamically assigned. You will have to 
             WARNING: The USER_ID variable is not set. Defaulting to a blank string.
             0.0.0.0:xxxx
 
-        where ``xxxx`` is the assigned port ``$SERVER_PORT`` 
+        where ``xxxx`` is the assigned port ``$SERVER_PORT``
 
     * To login either via OMERO.insight or OMERO.cli use ``$SERVER_PORT`` as the port value
 and ``devspace_openstack_ip`` as the server value. You **must** use the secure connection.
@@ -306,23 +306,20 @@ forked to your GitHub account:
 * [openmiscrocopy/bioformats](https://github.com/openmicroscopy/bioformats)
 
 If you do not have some of the repositories forked, you will need to remove the jobs from the list
-of jobs to run either from the Trigger job [configuration](home/jobs/Trigger/config.xml) 
+of jobs to run either from the Trigger job [configuration](home/jobs/Trigger/config.xml)
 or directly from the Jenkins UI i.e. ``Trigger > Configure``.
 
 # New jobs
 
 It is recommended that new jobs should be defined using [Jenkinsfile pipelines](https://jenkins.io/doc/book/pipeline/jenkinsfile/) in the target repository as this makes it easier to maintain jobs.
-Creating a new job called `JOBNAME` should then be as easy as:
+Most Jenkins Pipeline jobs can share the same configuration apart from the repository URL.
+If you do not require any special configuration use the [`TEMPLATE-pipeline-job-config.xml`](TEMPLATE-pipeline-job-config.xml) template by adding the job and parameters to [`pipeline-configs.yaml`](pipeline-configs.yaml).
+Supported parameters are documented in that file.
 
-    mkdir home/jobs/JOBNAME
-    cp TEMPLATE-pipeline-job-config.xml home/jobs/JOBNAME/config.xml
+The `rename.py` script will create the required job configurations from `pipeline-configs.yaml` as well as performing the renaming steps.
+If for some reason you want to create the new job without running `rename.py` you can just run `createpipelinejobs.py`.
 
-Replace the following strings in `home/jobs/JOBNAME/config.xml`:
-- `[DESCRIPTION]`: Job description, recommended
-- `[REPOSITORY]`: GitHub username (typically either `openmicroscopy` or `SPACEUSER`) and repository
-- `Jenkinsfile`: If you have multiple `Jenkinsfile`s change this to the required file
-
-Alternatively create a new Pipeline job in the Jenkins web-interface in the usual way.
+Alternatively create a new job in the Jenkins web-interface in the usual way.
 
 # Default packages used
 

--- a/TEMPLATE-pipeline-job-config.xml
+++ b/TEMPLATE-pipeline-job-config.xml
@@ -1,0 +1,47 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.31">
+  <actions>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction plugin="pipeline-model-definition@1.3.6"/>
+    <org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction plugin="pipeline-model-definition@1.3.6">
+      <jobProperties/>
+      <triggers/>
+      <parameters/>
+      <options/>
+    </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
+  </actions>
+  <description>[DESCRIPTION]</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.64">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@4.0.0-rc">
+      <configVersion>2</configVersion>
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>https://github.com/[REPOSITORY].git</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>SPACEBRANCH</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+      <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+      <submoduleCfg class="list"/>
+      <extensions>
+        <hudson.plugins.git.extensions.impl.SubmoduleOption>
+          <disableSubmodules>false</disableSubmodules>
+          <recursiveSubmodules>true</recursiveSubmodules>
+          <trackingSubmodules>false</trackingSubmodules>
+          <reference></reference>
+          <parentCredentials>false</parentCredentials>
+          <shallow>true</shallow>
+        </hudson.plugins.git.extensions.impl.SubmoduleOption>
+        <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
+      </extensions>
+    </scm>
+    <scriptPath>Jenkinsfile</scriptPath>
+    <lightweight>true</lightweight>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/TEMPLATE-pipeline-job-config.xml
+++ b/TEMPLATE-pipeline-job-config.xml
@@ -34,6 +34,7 @@
           <trackingSubmodules>false</trackingSubmodules>
           <reference></reference>
           <parentCredentials>false</parentCredentials>
+          <timeout>{CLONE_TIMEOUT}</timeout>
           <shallow>true</shallow>
         </hudson.plugins.git.extensions.impl.SubmoduleOption>
         <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>

--- a/TEMPLATE-pipeline-job-config.xml
+++ b/TEMPLATE-pipeline-job-config.xml
@@ -9,20 +9,20 @@
       <options/>
     </org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction>
   </actions>
-  <description>[DESCRIPTION]</description>
+  <description>{DESCRIPTION}</description>
   <keepDependencies>false</keepDependencies>
-  <properties/>
+  {PROPERTIES}
   <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.64">
     <scm class="hudson.plugins.git.GitSCM" plugin="git@4.0.0-rc">
       <configVersion>2</configVersion>
       <userRemoteConfigs>
         <hudson.plugins.git.UserRemoteConfig>
-          <url>https://github.com/[REPOSITORY].git</url>
+          <url>https://github.com/{REPOSITORY}.git</url>
         </hudson.plugins.git.UserRemoteConfig>
       </userRemoteConfigs>
       <branches>
         <hudson.plugins.git.BranchSpec>
-          <name>SPACEBRANCH</name>
+          <name>{BRANCH}</name>
         </hudson.plugins.git.BranchSpec>
       </branches>
       <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -37,9 +37,16 @@
           <shallow>true</shallow>
         </hudson.plugins.git.extensions.impl.SubmoduleOption>
         <hudson.plugins.git.extensions.impl.CleanBeforeCheckout/>
+        <hudson.plugins.git.extensions.impl.CloneOption>
+          <shallow>false</shallow>
+          <noTags>false</noTags>
+          <reference></reference>
+          <timeout>{CLONE_TIMEOUT}</timeout>
+          <honorRefspec>false</honorRefspec>
+        </hudson.plugins.git.extensions.impl.CloneOption>
       </extensions>
     </scm>
-    <scriptPath>Jenkinsfile</scriptPath>
+    <scriptPath>{JENKINSFILE}</scriptPath>
     <lightweight>true</lightweight>
   </definition>
   <triggers/>

--- a/createpipelinejobs.py
+++ b/createpipelinejobs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import errno
+import os
+import yaml
+
+
+TEMPLATE_CONFIG_XML = 'TEMPLATE-pipeline-job-config.xml'
+JENKINS_JOBS_DIR = './home/jobs'
+
+PROPERTIES = """\
+  <properties>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers>
+        {TRIGGERS}
+      </triggers>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+  </properties>
+"""
+TRIGGER = """\
+        <jenkins.triggers.ReverseBuildTrigger>
+          <spec></spec>
+          <upstreamProjects>{AFTER_JOBNAME}</upstreamProjects>
+          <threshold>
+            <name>SUCCESS</name>
+            <ordinal>0</ordinal>
+            <color>BLUE</color>
+            <completeBuild>true</completeBuild>
+          </threshold>
+        </jenkins.triggers.ReverseBuildTrigger>
+"""
+
+
+def main():
+    with open(TEMPLATE_CONFIG_XML) as f:
+        template = f.read()
+    with open('pipeline-configs.yaml') as f:
+        cfg = yaml.load(f)
+
+    for (jobname, jobcfg) in cfg['jobs'].items():
+        new_job_dir = os.path.join(JENKINS_JOBS_DIR, jobname)
+        new_job_cfg = os.path.join(new_job_dir, 'config.xml')
+        print('Creating {} with configuration {}'.format(new_job_cfg, jobcfg))
+        if 'after' in jobcfg:
+            triggers = [TRIGGER.format(AFTER_JOBNAME=j)
+                        for j in jobcfg['after']]
+            properties = PROPERTIES.format(TRIGGERS='\n'.join(triggers))
+        else:
+            properties = '<properties/>'
+        job_config_xml = template.format(
+            DESCRIPTION=jobcfg['description'],
+            REPOSITORY=jobcfg['repository'],
+            BRANCH=jobcfg['branch'],
+            CLONE_TIMEOUT=jobcfg.get('clone_timeout', 10),
+            JENKINSFILE=jobcfg.get('jenkinsfile', 'Jenkinsfile'),
+            PROPERTIES=properties,
+        )
+        try:
+            os.mkdir(new_job_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+        with open(new_job_cfg, 'w') as f:
+            f.write(job_config_xml)
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline-configs.yaml
+++ b/pipeline-configs.yaml
@@ -12,8 +12,6 @@ jobs:
     repository: ome/omero-build
     branch: SPACEBRANCH
     jenkinsfile: Jenkinsfile.merge
-    after:
-      - OMERO-gradle-plugins-build
 
   OMERO-gradle-plugins-build:
     description: Build omero-gradle-plugins

--- a/pipeline-configs.yaml
+++ b/pipeline-configs.yaml
@@ -7,16 +7,28 @@ jobs:
   #   jenkinsfile: Path and name of the Jenkinsfile, default Jenkinsfile
   #   after: [Automatically run this job after any of these jobs have been run]
 
+  OMERO-gradle-plugins-push:
+    description: Run scc merge and bump versions on omero-build
+    repository: ome/omero-build
+    branch: SPACEBRANCH
+    jenkinsfile: Jenkinsfile.merge
+    after:
+      - OMERO-gradle-plugins-build
+
   OMERO-gradle-plugins-build:
     description: Build omero-gradle-plugins
     repository: SPACEUSER/omero-gradle-plugins
     branch: SPACEBRANCH
+    after:
+      - OMERO-gradle-plugins-push
 
   OMERO-build-push:
     description: Run scc merge and bump versions on omero-build
-    repository: openmicroscopy/omero-build
+    repository: ome/omero-build
     branch: SPACEBRANCH
     jenkinsfile: Jenkinsfile.merge
+    after:
+      - OMERO-gradle-plugins-build
 
   OMERO-build-build:
     description: Build omero-build

--- a/pipeline-configs.yaml
+++ b/pipeline-configs.yaml
@@ -1,7 +1,7 @@
 jobs:
   # JOB-name:
   #   description: Description of job
-  #   repository: github-user/github-repo.git
+  #   repository: github-user/github-repo
   #   branch: branch to build
   #   clone_timeout: Timeout in minutes for git clone, default 10 minutes
   #   jenkinsfile: Path and name of the Jenkinsfile, default Jenkinsfile

--- a/pipeline-configs.yaml
+++ b/pipeline-configs.yaml
@@ -1,0 +1,26 @@
+jobs:
+  # JOB-name:
+  #   description: Description of job
+  #   repository: github-user/github-repo.git
+  #   branch: branch to build
+  #   clone_timeout: Timeout in minutes for git clone, default 10 minutes
+  #   jenkinsfile: Path and name of the Jenkinsfile, default Jenkinsfile
+  #   after: [Automatically run this job after any of these jobs have been run]
+
+  OMERO-gradle-plugins-build:
+    description: Build omero-gradle-plugins
+    repository: SPACEUSER/omero-gradle-plugins
+    branch: SPACEBRANCH
+
+  OMERO-build-push:
+    description: Run scc merge and bump versions on omero-build
+    repository: openmicroscopy/omero-build
+    branch: SPACEBRANCH
+    jenkinsfile: Jenkinsfile.merge
+
+  OMERO-build-build:
+    description: Build omero-build
+    repository: SPACEUSER/omero-build
+    branch: SPACEBRANCH_merge_trigger
+    after:
+      - OMERO-build-push

--- a/pipeline-configs.yaml
+++ b/pipeline-configs.yaml
@@ -9,7 +9,7 @@ jobs:
 
   OMERO-gradle-plugins-push:
     description: Run scc merge and bump versions on omero-build
-    repository: ome/omero-build
+    repository: ome/omero-gradle-plugins
     branch: SPACEBRANCH
     jenkinsfile: Jenkinsfile.merge
 

--- a/pipeline-configs.yaml
+++ b/pipeline-configs.yaml
@@ -16,7 +16,7 @@ jobs:
   OMERO-gradle-plugins-build:
     description: Build omero-gradle-plugins
     repository: SPACEUSER/omero-gradle-plugins
-    branch: SPACEBRANCH
+    branch: SPACEBRANCH_merge_trigger
     after:
       - OMERO-gradle-plugins-push
 

--- a/rename.py
+++ b/rename.py
@@ -5,6 +5,8 @@ import fileinput
 import fnmatch
 import os
 import re
+import createpipelinejobs
+
 
 EXCLUDE = ["builds", "workspace", "fingerprints"]
 
@@ -32,6 +34,8 @@ def replace(name, branch, uid, user):
   return cnt
 
 if __name__ == "__main__":
+  if os.path.exists('pipeline-configs.yaml'):
+      createpipelinejobs.main()
   parser = argparse.ArgumentParser()
   parser.add_argument("--uid", type=int, default=os.getuid())
   parser.add_argument("name")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-ansible==2.4.1
-shade
+yaml


### PR DESCRIPTION
In theory pipeline jobs should be almost identical to each other as far as Jenkins is concerned.
This means we can pretty much copy and paste a standard job config.

This currently adds jobs for:
- OMERO-gradle-plugins-build (not a merge build due to https://github.com/ome/build-infra/issues/2 https://github.com/ome/omero-gradle-plugins/pull/6)
- OMERO-build-push
- OMERO-build-build

This should provide an easy way to add future jobs as long as they use an embedded Jenkinsfile, and I think it'd be worth changing some of the existing jobs too to ensure they're maintained.