### PR TITLE
Use bio-formats-build as the source for the Bio-Formats Docker image

### DIFF
--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -20,6 +20,7 @@
     <submoduleCfg class="list"/>
     <extensions>
       <hudson.plugins.git.extensions.impl.PruneStaleBranch/>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
     </extensions>
   </scm>
   <assignedNode>docker</assignedNode>

--- a/home/jobs/BIOFORMATS-image/config.xml
+++ b/home/jobs/BIOFORMATS-image/config.xml
@@ -8,7 +8,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git://github.com/SPACEUSER/bioformats</url>
+        <url>git://github.com/SPACEUSER/bio-formats-build</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>


### PR DESCRIPTION
This change has been driven on east-ci as part of the bio-formats-build components coupling work but was never ported to the upstream devspace.


/cc @manics 