### PR TITLE
Install plugin.txt dependencies automatically

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER OME
 ENV JAVA_OPTS "-Dhudson.model.DirectoryBrowserSupport.CSP="
 
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 
 USER root
 RUN chown -R jenkins:jenkins /var/jenkins_home


### PR DESCRIPTION
A future cleanup could involve cleaning up plugins.txt to only list the direct requirements for devspace, and remove the dependencies