### PR TITLE
Allow fixing the SSL/TCP ports of the OMERO test server.

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,8 @@ NGINX_PORT=
 NGINX_SSL_PORT=
 OMERO_SERVER_SSL=
 OMERO_SERVER_TCP=
+OMERO_SERVER_TEST_SSL=
+OMERO_SERVER_TEST_TCP=
 
 # Variables for changing what Bio-Formats tests
 REPO_CURATED=/tmp/curated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,8 @@ services:
         extra_hosts:
             - "testintegration:127.0.0.1"
         ports:
-            - "14064"
-            - "14063"
+            - "${OMERO_SERVER_TEST_SSL}14064"
+            - "${OMERO_SERVER_TEST_TCP}14063"
 
     omero:
         build:


### PR DESCRIPTION
`OMERO_SERVER_TEST_SSL` and `OMERO_SERVER_TEST_TCP`  (with a colon suffix) now allow fixing the container's port for reaching the OMERO server that runs the integration tests.