### PR TITLE
Update JAVAVER in Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/devslave-c7:0.6.1
 
 MAINTAINER OME
 
-ARG JAVAVER=openjdk18
+ARG JAVAVER=openjdk1.8
 ARG ICEVER=ice36
 
 # skip some omero-install

--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/devslave-c7:0.6.1
 
 MAINTAINER OME
 
-ARG JAVAVER=openjdk18
+ARG JAVAVER=openjdk1.8
 ARG ICEVER=ice36-devel
 
 # skip some omero-install

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,7 +2,7 @@ FROM openmicroscopy/devslave-c7:0.6.1
 
 MAINTAINER OME
 
-ARG JAVAVER=openjdk18
+ARG JAVAVER=openjdk1.8
 ARG ICEVER=noice
 
 # make ICEVERSION environment variable to use in OMERO-web job


### PR DESCRIPTION
The devslave-c7 upgrade bumps the base omero-install to 5.5.0-m3 including the breaking change in environment variable. This should minimally restore Travis and deployment

This should fix the Travis status although I am unclear why it was not flagged by #134 