### PR TITLE
OMERO.web: obtain external scheme from HTTP_X_FORWARDED_PROTO_WEB_PROXY

### DIFF
--- a/home/jobs/OMERO-web/config.xml
+++ b/home/jobs/OMERO-web/config.xml
@@ -96,6 +96,8 @@ $OMERO_DIST/bin/omero config set omero.web.prefix $WEB_PREFIX
 $OMERO_DIST/bin/omero config set omero.web.static_url $WEB_PREFIX&apos;/static/&apos;
 $OMERO_DIST/bin/omero config set omero.web.static_root $HOME&apos;/static/web/&apos;
 
+$OMERO_DIST/bin/omero config set omero.web.secure_proxy_ssl_header &apos;[&quot;HTTP_X_FORWARDED_PROTO_WEB_PROXY&quot;, &quot;https&quot;]&apos;
+
 $OMERO_DIST/bin/omero config set omero.web.session_engine &apos;django.contrib.sessions.backends.cache&apos;
 $OMERO_DIST/bin/omero config set omero.web.caches &apos;{&quot;default&quot;: {&quot;BACKEND&quot;: &quot;django_redis.cache.RedisCache&quot;,&quot;LOCATION&quot;: &quot;redis://redis:6379/0&quot;}}&apos;
 


### PR DESCRIPTION
If OMERO.web is behind multiple (possible insecure) nginx proxies this header can be set by the front-end proxy to indicate the scheme

See https://github.com/IDR/deployment/blob/IDR-0.6.8/ansible/group_vars/omero-hosts.yml#L129-L131

Untested